### PR TITLE
Join all the arguments to form the file name if more than one argument is provided

### DIFF
--- a/usr/lib/captain/captain.py
+++ b/usr/lib/captain/captain.py
@@ -486,11 +486,11 @@ class URLApp():
         except Exception as e:
             self.uih.show_critical(_("The package '%s' could not be installed") % self.pkgname, str(e))
 
-if len(sys.argv) != 2:
+if len(sys.argv) < 2:
     print("Usage: captain filename.deb")
     sys.exit(1)
 
-argument = os.path.expanduser(sys.argv[1])
+argument = os.path.expanduser(' '.join(sys.argv[1:]))
 
 if "apt://" in argument:
     app = URLApp(argument)


### PR DESCRIPTION
This will join all the arguments to form the file name in case of more than one argument is provided.

Another way to solve this would be to guarantee the file would have proper formating when sent to the command tool (either using double quotes or a back slash to garantee the file path would be considered as a single argument when passed to the command line utility), which would have to be handled from nemo I suppose.

Trying to add single or double quotes to the **%u** argument of the Exec field in the .desktop file (from the piece of code shown below) didn't work as a solution from the tests I made.
https://github.com/linuxmint/captain/blob/d01f8d14eb39678f4d41ecd6680632d9a0917552/data/captain.desktop.in#L4

closes https://github.com/linuxmint/mint22.1-beta/issues/87