### PR TITLE
Bugfix: fixed url parsing to accept apt: and apt://

### DIFF
--- a/usr/lib/captain/captain.py
+++ b/usr/lib/captain/captain.py
@@ -13,6 +13,7 @@ import apt
 import apt.debfile
 import re
 from mimetypes import guess_type
+from urllib.parse import urlparse
 import aptkit.simpleclient
 import aptkit.enums
 
@@ -416,8 +417,10 @@ class URLApp():
         self.uih = UIHelper(None)
 
         # parse URL
-        url = url.replace("apt://", "")
-        self.pkgname = url.split("?")[0]
+        parsed_url = urlparse(url)
+        self.pkgname = parsed_url.path
+        if not self.pkgname:
+            self.pkgname = parsed_url.netloc
 
         # update the cache
         apt = aptkit.simpleclient.SimpleAPTClient(None)
@@ -492,7 +495,7 @@ if len(sys.argv) != 2:
 
 argument = os.path.expanduser(sys.argv[1])
 
-if "apt://" in argument:
+if argument.lower().startswith("apt:"):
     app = URLApp(argument)
 else:
     if not os.path.exists(argument):


### PR DESCRIPTION
This PR enhances the URL parsing of captain to allow for both flavors of apt urls. According to Ubuntu [AptUrl](https://wiki.ubuntu.com/AptUrl) page, apt urls can start with both "apt:" and "apt://".

resolves https://github.com/linuxmint/captain/issues/10