### PR TITLE
Toggle word wrap on `textview_file_content`

### DIFF
--- a/usr/share/captain/deb_package.ui
+++ b/usr/share/captain/deb_package.ui
@@ -507,6 +507,7 @@
                                 <property name="right-margin">6</property>
                                 <property name="cursor-visible">False</property>
                                 <property name="monospace">True</property>
+                                <property name="wrap-mode">char</property>
                               </object>
                             </child>
                           </object>


### PR DESCRIPTION
Use word wrap to see file contents to work around the `GTK` very long line overlap bug.

This change uses `char` word wrap mode over `word` and `word-char` modes because `char` mode handles minified `.js` and `.json` files better.

Minified JavaScript and JSON files contain almost no whitespace, so other modes add a newline character in the middle of the line sometimes.

Reference: https://docs.gtk.org/gtk3/enum.WrapMode.html

- Closes #17

-----
**Before:**
<img width="751" height="401" alt="captain-no-wrap" src="https://github.com/user-attachments/assets/9daf0c58-02a9-4265-a555-89ad2993c975" />

**After:**
<img width="751" height="401" alt="captain-word-wrap-char" src="https://github.com/user-attachments/assets/3a285d8a-62b8-49e2-a6b6-0ae84515302c" />
