### PR TITLE
Keep original package description

### DIFF
--- a/usr/lib/captain/captain.py
+++ b/usr/lib/captain/captain.py
@@ -395,7 +395,7 @@ def set_description(textview, summary, description):
         else:
             summary = summary + "\n"
 
-        text = "%s\n" % summary.title()
+        text = "%s\n" % summary
 
         # Parse new lines (this is necessary because APT introduces random new lines, multiple space
         # chars and . lines)


### PR DESCRIPTION
This PR removes the `.title()` call to not modify the package description letter case.

It's not a good idea to modify the displayed package metadata, especially when the text is in a language with fixed rules for upper/lowercase words or contains proper names, links etc. The `title()` call here causes a lot of confusion for those users, with no benefit for the GUI.

fixes #15 